### PR TITLE
Add support for MDX node.internal.contentFilePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "esca-scripts build --dist './' --no-remove",
     "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "reset": "esca-scripts reset",
     "test": "npm run build && esca-scripts test",
     "travis": "opn https://travis-ci.org/entr/gatsby-plugin-netlify-cms-paths/branches"

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -49,7 +49,7 @@ exports.onCreateNode = async ({ node, getNode }, options) => {
 	}
 	
 	if (node.internal.type === `MarkdownRemark`) {
-		nodeAbsPath = node.fileAbsolutePath
+		nodeAbsPath = node.fileAbsolutePath || node.internal.contentFilePath
 
 		if(typeof node.frontmatter === `object`) {
 			await walkObject(node.frontmatter, iteratee, commonProps)


### PR DESCRIPTION
Add support for MDX node.internal.contentFilePath as `fileabsolutePath` is now removed from MDX